### PR TITLE
Bump Microsoft.Extensions.Identity.Core from 8.0.6 to 8.0.7

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,7 +32,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.4" />
     <PackageVersion Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.6" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-    <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="8.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="8.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="$(SystemExtensionVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="$(VSCodeGeneratorVersion)" />
     <PackageVersion Include="Microsoft.Web.LibraryManager.Build" Version="2.1.175" />


### PR DESCRIPTION
Bumps Microsoft.Extensions.Identity.Core from 8.0.6 to 8.0.7.

---
updated-dependencies:
- dependency-name: Microsoft.Extensions.Identity.Core dependency-type: direct:production update-type: version-update:semver-patch ...